### PR TITLE
Allow ComparisonExpression to be an AdditiveExpression

### DIFF
--- a/flux.rkt
+++ b/flux.rkt
@@ -235,7 +235,8 @@
   (UnaryLogicalExpression ComparisonExpression
                           (UnaryLogicalOperator UnaryLogicalExpression))
 
-  (ComparisonExpression MultiplicativeExpression
+  (ComparisonExpression AdditiveExpression
+                        MultiplicativeExpression
                         (ComparisonExpression ComparisonOperator MultiplicativeExpression))
 
   (AdditiveExpression MultiplicativeExpression

--- a/flux_test.rkt
+++ b/flux_test.rkt
@@ -94,10 +94,11 @@
   (test-match Flux ConditionalExpression
                (term ("if" a "then" b "else" c)
                      ))
+
   ;; TODO
-  ;; (test-match Flux Expression
-  ;;              (term (a "+" b)
-  ;;                    ))
+  (test-match Flux Expression
+               (term (a "+" b)
+                     ))
 
   ;; TODO
   ;; builtin filter : (<-tables: [T], fn: (r: T) => bool) => [T]


### PR DESCRIPTION
I think this might correct a bug in the spec.

But does this break operator precedence? 🤔 